### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,12 +335,12 @@ export default function counter( state = initialState, action ) {
       return {
         currentValue: state.previousValues[ 0 ],
         futureValues: [ state.currentValue, ...state.futureValues ],
-        previousValues: state.previousValues.slice( 1, state.previousValues.length )
+        previousValues: state.previousValues.slice( 1 )
       };
     case REDO:
       return {
         currentValue: state.futureValues[ 0 ],
-        futureValues: state.futureValues.slice( 1, state.futureValues.length ),
+        futureValues: state.futureValues.slice( 1 ),
         previousValues: [ state.currentValue, ...state.previousValues ]
       };
     default:
@@ -378,7 +378,7 @@ In this step, we'll import `undo` and `redo` action creators into our `App.js` a
 * Open `./src/App.js`.
 * Import `undo` and `redo` action creators.
 * Add `undo` and `redo` to `mapDispatchToProps`.
-* Destrcuture `undo` and `redo` from `props`.
+* Destrucuture `undo` and `redo` from `props`.
 * Hook up the `undo` and `redo` buttons to their respective action creators.
 
 ### Solution


### PR DESCRIPTION
Removed `state.futureValues.length` from the `.slice()` function in `undo` and `redo`. It was an unnecessary piece of code that was confusing some students. Since we are removing the first value from the array and leaving the rest of the array, `.slice(1)` is enough, and we don't need to specify an end index.